### PR TITLE
Build pccts locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,8 @@ install_local_tokei: build_tokei
 build_cccc: target_dir
 	@echo 
 	@echo Building CCCC...
-	@echo REMEMBER: CCCC requires the "pccts" package, you have to install it first.
 	cp -r $(TOOLS_PATH)/CCCC $(CCCC_TMP_PATH)
+	cd $(CCCC_TMP_PATH)/pccts && make && cd ..
 	cd $(CCCC_TMP_PATH) && make cccc && make test
 	# ---  CCCC   ---
 
@@ -60,22 +60,6 @@ install_local_cccc: build_cccc
 	@echo
 	-mkdir -p $(CCCC_DEST_PATH)
 	cp $(CCCC_TMP_PATH)/cccc/cccc $(CCCC_DEST_PATH)
-
-
-
-# OLD VERSION (<3.1.5)
-#build_cccc: target_dir
-#	@echo 
-#	@echo Building CCCC...
-#	cp -r $(TOOLS_PATH)/CCCC/cccc-3.1.4 $(CCCC_TMP_PATH)
-#	cd $(CCCC_TMP_PATH) && make pccts && make cccc && make test
-#	# ---  CCCC   ---
-
-#install_local_cccc: build_cccc
-#	@echo
-#	-mkdir -p $(CCCC_DEST_PATH)
-#	cp $(CCCC_TMP_PATH)/cccc/cccc $(CCCC_DEST_PATH)
-# OLD VERSION (<3.1.5)
 
 
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,6 @@ Used for: LOC, CLOC
 ### CCCC
 Repo @ last available version + already patched.
 Used for: C&K, CC, WMC
-This tool requires "pccts" as a dependency, you can install it from your package manager.
-    Ubuntu users: `# apt-get install pccts`
-    Arch Linux users can build `pccts` from AUR.
 
     * Building: Ok
     * Local installation: Ok


### PR DESCRIPTION
Do not use `pccts` as an external dependency.